### PR TITLE
自動更新機能の追加

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -91,7 +91,7 @@ $(function(){
           }
         })
         .fail(function() {
-          console.log('error');
+          alert("メッセージ送信に失敗しました");
         });
       };
   if (document.location.href.match(/\/groups\/\d+\/messages/)) {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,5 @@
 $(function(){
+  
 
       function buildHTML(message){
         if ( message.image ) {
@@ -64,4 +65,36 @@ $(function(){
           alert("メッセージ送信に失敗しました");
         });
       })
+      var reloadMessages = function() {
+        //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+        last_message_id = $('.message:last').data("message-id");
+        $.ajax({
+          //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+          url: "api/messages",
+          //ルーティングで設定した通りhttpメソッドをgetに指定
+          type: 'get',
+          dataType: 'json',
+          //dataオプションでリクエストに値を含める
+          data: {id: last_message_id}
+        })
+        .done(function(messages) {
+          if (messages.length !== 0) {
+            //追加するHTMLの入れ物を作る
+            var insertHTML = '';
+            //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+            $.each(messages, function(i, message) {
+            insertHTML += buildHTML(message)
+            });
+            //メッセージが入ったHTMLに、入れ物ごと追加
+            $('.contents__main').append(insertHTML);
+            $('.contents__main').animate({ scrollTop: $('.contents__main')[0].scrollHeight});
+          }
+        })
+        .fail(function() {
+          console.log('error');
+        });
+      };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__upper
     .upper__name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
メッセージ画面の自動更新機能を追加した。
- カスタムデータ属性の追加
- webAPIの追加
- json形式の応答を実装
- 7秒ごとに画面更新を実装
- 別画面でもスクロールできるように機能追加
- 自動更新を行わない画面は自動更新を行わないように設定

# Why
- ユーザーの利便性のため（わざわざリロードしなくても良いように）
- リアルタイムの内容を見れるようにするため

# メッセージのみ

<a href="https://gyazo.com/df51e0c674731ebdf3582022f991de57"><img src="https://i.gyazo.com/df51e0c674731ebdf3582022f991de57.gif" alt="Image from Gyazo" width="1000"/></a>

# 画像のみ

<a href="https://gyazo.com/3178f7b8ceb190743a0567a6b1d0020b"><img src="https://i.gyazo.com/3178f7b8ceb190743a0567a6b1d0020b.gif" alt="Image from Gyazo" width="1000"/></a>

# メッセージと画像　両方

<a href="https://gyazo.com/f4dba9cc158f023d9329fb209058fd85"><img src="https://i.gyazo.com/f4dba9cc158f023d9329fb209058fd85.gif" alt="Image from Gyazo" width="1000"/></a>